### PR TITLE
tweaks for SU2 easyconfig

### DIFF
--- a/easybuild/easyconfigs/s/SU2/SU2-7.0.6-foss-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/s/SU2/SU2-7.0.6-foss-2020a-Python-3.8.2.eb
@@ -21,6 +21,10 @@ source_urls = [GITHUB_SOURCE]
 sources = ['v%(version)s.tar.gz']
 checksums = ['5be22a992952b08f16bb80658f6cbe29c62a27e20236eccd175ca58dbc4ed27d']
 
+builddependencies = [
+    ('Autotools', '20180311'),
+]
+
 dependencies = [
     ('Python', '3.8.2'),
     ('ParaView', '5.8.0', '-Python-%(pyver)s-mpi'),
@@ -28,31 +32,21 @@ dependencies = [
 ]
 
 preconfigopts = "./bootstrap &&"
-configopts = 'CXXFLAGS="$CXXFLAGS" --enable-mpi --with-cc=mpicc --with-cxx=mpicxx'
+configopts = 'CXXFLAGS="$CXXFLAGS" --enable-mpi --with-cc="$MPICC" --with-cxx="$MPICXX"'
 
 sanity_check_paths = {
-    'dirs': ["bin/"],
-    'files': ["bin/SU2_CFD",
-              "bin/SU2_CFD.py",
-              "bin/SU2_DEF",
-              "bin/SU2_DOT",
-              "bin/SU2_GEO",
-              "bin/SU2_MSH",
-              "bin/SU2_SOL",
-              "bin/compute_multipoint.py",
-              "bin/compute_polar.py",
-              "bin/compute_uncertainty.py",
-              "bin/continuous_adjoint.py",
-              "bin/direct_differentiation.py",
-              "bin/discrete_adjoint.py",
-              "bin/finite_differences.py",
-              "bin/fsi_computation.py",
-              "bin/merge_solution.py",
-              "bin/mesh_deformation.py",
-              "bin/package_tests.py",
-              "bin/parallel_computation_fsi.py",
-              "bin/parallel_computation.py",
-              "bin/set_ffd_design_var.py",
-              "bin/shape_optimization.py",
-              ],
+    'files': ['bin/SU2_CFD', 'bin/SU2_CFD.py', 'bin/SU2_DEF', 'bin/SU2_DOT', 'bin/SU2_GEO', 'bin/SU2_MSH',
+              'bin/SU2_SOL', 'bin/compute_multipoint.py', 'bin/compute_polar.py', 'bin/compute_uncertainty.py',
+              'bin/continuous_adjoint.py', 'bin/direct_differentiation.py', 'bin/discrete_adjoint.py',
+              'bin/finite_differences.py', 'bin/fsi_computation.py', 'bin/merge_solution.py',
+              'bin/mesh_deformation.py', 'bin/package_tests.py', 'bin/parallel_computation_fsi.py',
+              'bin/parallel_computation.py', 'bin/set_ffd_design_var.py', 'bin/shape_optimization.py'],
+    'dirs': [],
 }
+
+sanity_check_commands = [
+    "SU2_CFD --help",
+    "SU2_CFD.py --help",
+]
+
+moduleclass = 'cae'


### PR DESCRIPTION
* add Autotools build dep for SU2
* use $MPICC and $MPICXX rather than hardcoding mpicc/mpicxx
* clean up sanity_check_paths
* add sanity check commands
* add missing moduleclass

@alirezaghavaminia update for https://github.com/easybuilders/easybuild-easyconfigs/pull/11446

The `SU2_CFD.py --help` sanity check command fails, it seems like the `SU2_RUN` environment variable is expected to be set?